### PR TITLE
Add Apache SkyWalking Infra E2E repo

### DIFF
--- a/api-go/config/multi-repo.yaml
+++ b/api-go/config/multi-repo.yaml
@@ -39,6 +39,7 @@ apache/skywalking:
     - apache/skywalking-banyandb
     - apache/skywalking-java
     - apache/skywalking-banyandb-java-client
+    - apache/skywalking-infra-e2e
     - SkyAPM/SkyAPM-dotnet
     - SkyAPM/go2sky
     - SkyAPM/go2sky-plugins


### PR DESCRIPTION
Follow https://github.com/apache/skywalking-website/pull/324#issuecomment-913641064, we need to add the contributor count of https://github.com/apache/skywalking-infra-e2e project, thanks :)